### PR TITLE
Update to Tools page Privacy Policy copy

### DIFF
--- a/app/templates/tools.hbs
+++ b/app/templates/tools.hbs
@@ -63,7 +63,7 @@ Questions best practices:
   * We will only use your email in accordance with WNYC's Privacy Policy: wnyc.org/privacy.
   * We will only use your email in accordance with WQXR’s Privacy Policy: wqxr.org/privacy.
   * We will only use your email in accordance with New Sounds’ Privacy Policy: newsounds.org/privacy.
-  * We will only use your email in accordance with WNYC Studios’ Privacy Policy: wnycstudios.org/privacy.
+  * We will only use your email in accordance with WNYC Studios’ Privacy Policy: wnyc.org/privacy.
 * When asking a user gender please word the question as such:
   * Which best represents your gender?
   * Female


### PR DESCRIPTION
Replaced "wnycstudios.org/privacy" with "wnyc.org/privacy"
The former is a 404; until we have a real studios privacy policy page we will use wnyc.org version.